### PR TITLE
Build openbsd-compat/clock_gettime.c with libasr

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,6 +5,7 @@ libasr_la_SOURCES =	asr.c asr_debug.c asr_utils.c getaddrinfo_async.c	\
 			getnetnamadr_async.c res_search_async.c res_send_async.c
 
 #openbsd-compat
+libasr_la_SOURCES +=	$(top_srcdir)/openbsd-compat/clock_gettime.c
 libasr_la_SOURCES +=	$(top_srcdir)/openbsd-compat/fgetln.c
 libasr_la_SOURCES +=	$(top_srcdir)/openbsd-compat/reallocarray.c
 libasr_la_SOURCES +=	$(top_srcdir)/openbsd-compat/res_hnok.c


### PR DESCRIPTION
MacOS does not implement `clock_gettime()`. The implementation in openbsd-compat is
needed to use any `clock_gettime()` calls in libasr. Building libasr and
linking libasr with other binaries do not cause any errors, but, try to run the
linked binary and this is what appears...

    dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
      Referenced from: /usr/local/opt/libasr/lib/libasr.0.dylib
      Expected in: flat namespace

    dyld: Symbol not found: _clock_gettime
      Referenced from: /usr/local/opt/libasr/lib/libasr.0.dylib
      Expected in: flat namespace