### PR TITLE
Add a test for libasr

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,9 @@
 SUBDIRS =		src
 
 ACLOCAL_AMFLAGS =	-I m4
+
+TESTS=			tests/asr_simple
+check_PROGRAMS=		${TESTS}
+
+tests_asr_simple_SOURCES=	tests/asr_simple.c
+tests_asr_simple_LDADD=		src/libasr.la

--- a/tests/asr_simple.c
+++ b/tests/asr_simple.c
@@ -1,0 +1,21 @@
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <errno.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <string.h>
+#include <asr.h>
+
+int main() {
+    struct asr_query *query;
+    struct asr_result result;
+    const char *hostname = "localhost";
+
+    query = gethostbyname_async(hostname, NULL);
+    asr_run_sync(query, &result);
+    if (errno != 0) {
+            printf("asr run error: %s\n", strerror(errno));
+            return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
While writing the Homebrew formula for `libasr`, I wrote a test that found issue #14 when testing the installed package. I figure adding the test to the project would be a good start for adding more tests.

I don't know a lot about automake, so I pretty much just copied what I found at https://autotools.io/automake/nonrecursive.html#idm45453221108880 for reference. Let me know if it needs to be revised.