### PR TITLE
Allow for future automake versions

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -36,7 +36,7 @@ aclocalflags="`sed -ne 's/^[ \t]*ACLOCAL_AMFLAGS[ \t]*=//p' Makefile.am 2>/dev/n
 
 # Check for automake
 amvers="no"
-for v in 15 14 13 12 11 10 9 8 7 6 5; do
+for v in 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5; do
   if automake-1.${v} --version >/dev/null 2>&1; then
     amvers="-1.${v}"
     break

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ AC_PATH_PROG([NROFF], [nroff])
 AC_PATH_PROG([MANDOC], [mandoc])
 AC_PROG_YACC
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 LT_INIT
 


### PR DESCRIPTION
Debian now carries automake 1.16, which wasn't accepted by the bootstrap script. This patch fixes https://bugs.debian.org/906477 .