### PR TITLE
getaddrinfo_async: Check return value of getservbyname_r earlier

### DIFF
--- a/src/getaddrinfo_async.c
+++ b/src/getaddrinfo_async.c
@@ -498,13 +498,12 @@ get_port(const char *servname, const char *proto, int numonly)
 #else
 	r = -1;
 #endif
+	if (r == -1)
+		return (-1); /* not found */
 	port = ntohs(se.s_port);
 #ifdef HAVE_ENDSERVENT_R
 	endservent_r(&sed);
 #endif
-
-	if (r == -1)
-		return (-1); /* not found */
 
 	return (port);
 }


### PR DESCRIPTION
If `getservbyname_r` fails (or `HAVE_GETSERVBYNAME_R_4_ARGS` is not defined)
it doesn't make any sense to access member of the `servent struct` as it
will not be initialized then. Calling `endservent_r` shouldn't be
necessary either then.

GCC 8 also complains about this code part when compiling with
the `-Wmaybe-uninitialized` flag.