### PR TITLE
Fix libtool link warning

### DIFF
--- a/openbsd-compat/Makefile.am
+++ b/openbsd-compat/Makefile.am
@@ -1,15 +1,15 @@
-noinst_LIBRARIES =		libopenbsdcompat.a
+noinst_LTLIBRARIES =	libopenbsdcompat.la
 
-libopenbsdcompat_a_SOURCES =	fgetln.c
-libopenbsdcompat_a_SOURCES +=	explicit_bzero.c
-libopenbsdcompat_a_SOURCES +=	reallocarray.c
-libopenbsdcompat_a_SOURCES +=	recallocarray.c
-libopenbsdcompat_a_SOURCES +=	res_hnok.c
-libopenbsdcompat_a_SOURCES +=	res_randomid.c
-libopenbsdcompat_a_SOURCES +=	strlcat.c
-libopenbsdcompat_a_SOURCES +=	strlcpy.c
-#libopenbsdcompat_a_SOURCES +=	strsep.c
-libopenbsdcompat_a_SOURCES +=	strtonum.c
+libopenbsdcompat_la_SOURCES =	fgetln.c
+libopenbsdcompat_la_SOURCES +=	explicit_bzero.c
+libopenbsdcompat_la_SOURCES +=	reallocarray.c
+libopenbsdcompat_la_SOURCES +=	recallocarray.c
+libopenbsdcompat_la_SOURCES +=	res_hnok.c
+libopenbsdcompat_la_SOURCES +=	res_randomid.c
+libopenbsdcompat_la_SOURCES +=	strlcat.c
+libopenbsdcompat_la_SOURCES +=	strlcpy.c
+#libopenbsdcompat_la_SOURCES +=	strsep.c
+libopenbsdcompat_la_SOURCES +=	strtonum.c
 
-libopenbsdcompat_a_CPPFLAGS =	-I$(builddir)/include
-libopenbsdcompat_a_CFLAGS =	-fPIC
+libopenbsdcompat_la_CPPFLAGS =	-I$(builddir)/include
+libopenbsdcompat_la_CFLAGS =	-fPIC

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,7 +14,7 @@ libasr_la_SOURCES +=	res_send_async.c
 include_HEADERS =	asr.h
 
 libasr_la_CPPFLAGS =	-I$(builddir)/../openbsd-compat/include
-libasr_la_LIBADD =	$(builddir)/../openbsd-compat/libopenbsdcompat.a
+libasr_la_LIBADD =	$(builddir)/../openbsd-compat/libopenbsdcompat.la
 libasr_la_LDFLAGS =	-version-info 0:3:0
 
 EXTRA_DIST =		asr_compat.h


### PR DESCRIPTION
Libtool produces a warning if we try to link a static lib into a shared lib (or any other .lx lib for that matter). The problem is not the linking which is fine since openbsd-compat uses -fPIC. The problem is that libtool doesn't know openbsd-compat is a convenience lib unless we use the proper suffix hence the warning.